### PR TITLE
Add z5 compact (E5823) to AEC blacklist

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -173,6 +173,7 @@ public class ApplicationContext extends MultiDexApplication implements Dependenc
         add("Moto G (5S) Plus");
         add("Moto G4");
         add("TA-1053");
+        add("E5823"); // Sony z5 compact
       }};
 
       Set<String> OPEN_SL_ES_WHITELIST = new HashSet<String>() {{


### PR DESCRIPTION
Following fixes for other models to reduce echo on callee side during Signal call. 

The problem has been reported for this model for example in #6241

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Xperia z5 compact (E5823), Android 7.1.2
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Adding z5 compact to the AEC blacklist to avoid echo on the callee's side during Signal voice/video calls.